### PR TITLE
Autoselect MFD_SYSCON when building an SMP kernel

### DIFF
--- a/arch/arm/mach-mcom02/Kconfig
+++ b/arch/arm/mach-mcom02/Kconfig
@@ -7,6 +7,7 @@ config ARCH_MCOM02
 	select HAVE_ARM_ARCH_TIMER
 	select HAVE_ARM_SCU if SMP
 	select HAVE_ARM_TWD if SMP
+	select MFD_SYSCON if SMP
 	select DW_APB_TIMER_OF
 	select ARM_ERRATA_754322
 	select ARM_ERRATA_764369 if SMP


### PR DESCRIPTION
Without MFD_SYSCON the kernel fails to bring up the secondary CPU(s) like this:
```
[    0.070000] CPU: Testing write buffer coherency: ok
[    0.070000] CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
[    0.080000] mcom02_map_device: could not find elvees,mcom-pmctr node
[    0.080000] Setting up static identity map for 0x400082c0 - 0x400082f4
[    0.090000] mcom02_boot_secondary: SMCTR is not mapped
[    0.100000] CPU1: failed to boot: -6
[    0.100000] Brought up 1 CPUs
```

Therefore select MFD_SYSCON automatically so the kernel "just works".
